### PR TITLE
Add configurable `QDRANT_HNSW_EF` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Configuration (env vars)
 - QDRANT_HOST: default http://127.0.0.1
 - QDRANT_PORT: default 5554
 - QDRANT_COLLECTION: default OKN-Graph
+- QDRANT_HNSW_EF: default 500
 - SENTENCE_MODEL_NAME: default all-MiniLM-L6-v2
 - HOST: HTTP server bind host (default 0.0.0.0)
 - PORT: HTTP server bind port (default 8000)

--- a/helm/frink-embedding-ui/templates/deployment.yaml
+++ b/helm/frink-embedding-ui/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: {{ .Values.env.qdrantPort | quote }}
             - name: "QDRANT_COLLECTION"
               value: {{ .Values.env.qdrantCollection }}
+            - name: "QDRANT_HNSW_EF"
+              value: {{ .Values.env.qdrantHnswEf | quote }}
             - name: "SENTENCE_MODEL_NAME"
               value: {{ .Values.env.model }}
             - name: "SENTENCE_TRANSFORMERS_HOME"

--- a/src/frink_embeddings_web/app.py
+++ b/src/frink_embeddings_web/app.py
@@ -13,6 +13,7 @@ def create_app() -> WrappedFlask:
     # Configuration from environment with sensible defaults
     qdrant_host = os.getenv("QDRANT_HOST", "http://127.0.0.1")
     qdrant_port = int(os.getenv("QDRANT_PORT", "5554"))
+    qdrant_hnsw_ef = int(os.getenv("QDRANT_HNSW_EF", "500"))
     collection = os.getenv("QDRANT_COLLECTION", "OKN-Graph")
     model_name = os.getenv("SENTENCE_MODEL_NAME", "all-MiniLM-L6-v2")
     graph_catalog = Path(os.getenv("GRAPH_CATALOG", "graphs.txt"))
@@ -23,6 +24,7 @@ def create_app() -> WrappedFlask:
 
     ctx = AppContext(
         client=client,
+        qdrant_hnsw_ef=qdrant_hnsw_ef,
         collection=collection,
         model=model,
         graph_catalog=graph_catalog,

--- a/src/frink_embeddings_web/context.py
+++ b/src/frink_embeddings_web/context.py
@@ -13,6 +13,7 @@ class AppContext:
     collection: str
     model: SentenceTransformer
     graph_catalog: Path
+    qdrant_hnsw_ef: int | None
 
     @property
     def graphs(self) -> list[str]:

--- a/src/frink_embeddings_web/query.py
+++ b/src/frink_embeddings_web/query.py
@@ -6,6 +6,7 @@ from qdrant_client.models import (
     MatchAny,
     MatchValue,
     ScoredPoint,
+    SearchParams,
 )
 from sentence_transformers import SentenceTransformer
 
@@ -53,6 +54,7 @@ def run_similarity_search(
     client: QdrantClient,
     model: SentenceTransformer,
     collection_name: str,
+    hnsw_ef: int | None,
 ) -> list[ScoredPoint]:
     vector = get_embedding(query_obj.feature, client, model, collection_name)
 
@@ -76,6 +78,8 @@ def run_similarity_search(
             ]
         )
 
+    search_params = SearchParams(hnsw_ef=hnsw_ef)
+
     return client.search(
         collection_name=collection_name,
         query_vector=vector.tolist(),
@@ -83,4 +87,5 @@ def run_similarity_search(
         with_payload=True,
         limit=query_obj.limit,
         offset=query_obj.offset,
+        search_params=search_params,
     )

--- a/src/frink_embeddings_web/routes.py
+++ b/src/frink_embeddings_web/routes.py
@@ -77,6 +77,7 @@ def post_query():
             client=ctx.client,
             model=ctx.model,
             collection_name=ctx.collection,
+            hnsw_ef=ctx.qdrant_hnsw_ef,
         )
     except Exception as e:
         msg, status = parse_error(e)
@@ -144,6 +145,7 @@ def post_query_view():
             client=ctx.client,
             model=ctx.model,
             collection_name=ctx.collection,
+            hnsw_ef=ctx.qdrant_hnsw_ef,
         )
     except Exception as e:
         msg, status = parse_error(e)


### PR DESCRIPTION
Adds a configurable setting for the query-time `hnsw_ef` parameter. The default now is 500, which might be high, but it's good for now.

New changes:

* New `QDRANT_HNSW_EF` environment variable for the Flask server
* Corresponding change in the helm configuration