### PR TITLE
Textify improvements

### DIFF
--- a/.agents/skills/textify/SKILL.md
+++ b/.agents/skills/textify/SKILL.md
@@ -9,6 +9,8 @@ The overall purpose is to generate textual representations of selected RDF nodes
 
 At a high level, the `okn-indexing` textification algorithm starts from configured RDF types, finds subject IRIs of those types, assigns each root node a human-readable label, walks selected outgoing graph edges, and turns predicate/object pairs into compact text lines. Object IRIs are represented by derived labels rather than full nested graph dumps. Label profiles can be defined separately from textification targets, so helper classes can provide good labels when they appear during graph walking without becoming standalone embedding documents. The output records group equivalent text under one record, preserve source IRIs, and include both a display label and embedding text.
 
+Predicate selection works two ways. `ignore_predicates` is a blacklist; `include_predicates` is an allowlist that, when non-empty, restricts the walk to exactly those predicates (with `ignore_predicates` still applied within it). Choose by which list is smaller and more stable: a graph with a handful of noisy predicates wants a blacklist, while a graph whose relation vocabulary is large or open-ended wants an allowlist.
+
 The end product is a concise, evidence-backed `config.toml` for `okn-indexing textify`, plus a report explaining the choices.
 
 ## CLI Utilities
@@ -45,7 +47,7 @@ The `okn-indexing` CLI is used to explore an HDT graph, evaluate candidate confi
     - Use `label_profiles` when helper classes need derived labels during graph walking without becoming textification targets.
     - Preserve `rdf:type` in embedding text by default because it is usually useful signal. Ignore type only when it is clearly unhelpful or misleading, such as ontology meta-types like `owl:Class`.
     - Set conservative `predicate_limit` and `expansion_limit`; prefer concise embedding text for `all-MiniLM-L6-v2`.
-    - Add `ignore_predicates` for noisy, huge, structural, or low-semantic-value predicates.
+    - Choose between `ignore_predicates` and `include_predicates` (see above). Reach for the allowlist when the sampler shows many distinct low-value predicates, when they follow no shared prefix you could enumerate, or when the graph's vocabulary will grow — a blacklist silently lets new noise back in, while an allowlist stays correct.
 7. Run `okn-indexing sample-targets` and, when useful, `okn-indexing textify` with small `--limit` values.
 8. Iterate until the sampled embedding text is compact, readable, and semantically useful.
 9. Write a report in the folder with the rest of the output titled `README.md`.

--- a/.agents/skills/textify/SKILL.md
+++ b/.agents/skills/textify/SKILL.md
@@ -44,10 +44,13 @@ The `okn-indexing` CLI is used to explore an HDT graph, evaluate candidate confi
     - Prefer `label_predicates` when a graph already has appropriate RDF predicates for names, titles, labels, or descriptions.
     - Only use `label_template`, `label_fields`, or `label_profiles` when no appropriate RDF label predicate exists, or when direct labels are too weak, too generic, or too verbose.
     - Do not create boilerplate label profiles that simply map `{name}` to a normal RDF name predicate; put that predicate in `label_predicates` instead.
+    - Before adopting a template, check the *coverage* of every field predicate. A template whose fields are missing on most roots renders as debris (`"apoptotic process ()"`), so a template is only worth it when its fields are nearly always present.
     - Use `label_profiles` when helper classes need derived labels during graph walking without becoming textification targets.
-    - Preserve `rdf:type` in embedding text by default because it is usually useful signal. Ignore type only when it is clearly unhelpful or misleading, such as ontology meta-types like `owl:Class`.
+    - Preserve `rdf:type` in embedding text by default because it is usually useful signal. Ignore type only when it is clearly unhelpful or misleading, such as ontology meta-types like `owl:Class`. In particular, when a target's `type` is the only type its roots carry, every record gets the same type line: drop it.
     - Set conservative `predicate_limit` and `expansion_limit`; prefer concise embedding text for `all-MiniLM-L6-v2`.
     - Choose between `ignore_predicates` and `include_predicates` (see above). Reach for the allowlist when the sampler shows many distinct low-value predicates, when they follow no shared prefix you could enumerate, or when the graph's vocabulary will grow — a blacklist silently lets new noise back in, while an allowlist stays correct.
+    - Put the label predicate itself in neither list but expect it in the walk: the embedding text already opens with a `label:` line, so leaving `rdfs:label` walkable prints the label twice. Exclude it from the walk (it is still used for labeling, which does not go through the walk).
+    - Set `expansion_limit = 0` unless you have a specific reason not to. `build_embedding_text` emits only level-0 lines, so a deeper walk is computed and then discarded — on a large graph that is a wasted subject scan per object.
 7. Run `okn-indexing sample-targets` and, when useful, `okn-indexing textify` with small `--limit` values.
 8. Iterate until the sampled embedding text is compact, readable, and semantically useful.
 9. Write a report in the folder with the rest of the output titled `README.md`.

--- a/.agents/skills/textify/SKILL.md
+++ b/.agents/skills/textify/SKILL.md
@@ -36,7 +36,11 @@ The `okn-indexing` CLI is used to explore an HDT graph, evaluate candidate confi
     - direct literal predicates that can become labels or useful text.
     - outgoing object predicates that lead to useful labeled entities.
     - object type distributions and object label predicates.
-    - high-fanout or noisy predicates to ignore.
+    - high-fanout predicates. Read `mean_per_subject` (shown as `per subject` in text output), not `count`, which is only occurrences across the sampled subjects. A predicate averaging one value per subject is an annotation; one averaging tens needs a decision.
+    - High fanout by itself does not mean "ignore" — what matters is whether the values are *exchangeable*. Ask whether an arbitrary handful of them still represents the whole:
+        * **Exchangeable** — siblings of the same kind, none more correct than another: the counties of a state, the authors of a paper, the ingredients of a product. Sampling a few is genuinely informative ("counties: Alameda, Butte, Calaveras"), and `predicate_limit` is exactly the right tool. Keep the predicate and cap it.
+        * **Ranked** — values that differ in how informative they are, typically an inferred or transitive hierarchy. A materialized `subClassOf` closure holds one direct parent among dozens of increasingly generic ancestors, so an arbitrary subset almost always misses the useful one and yields "temporally related to: occurrent". Here `predicate_limit` cannot help and the predicate is better excluded: the values are both uninformative and drawn from a small pool of generic terms that recur across the whole corpus, so they dilute every record in the same direction.
+    - Sampled values are chosen by a stable hash, so the choice is reproducible but not "the first" or "the best" ones. That is fine when the values are exchangeable and a problem when they are ranked.
 6. Draft `config.toml`.
     - Look at the file `indexing/models.py` for information about what a graph configuration consists of. You can also review `indexing/index.py` to understand the indexing algorithm.
     - Set target `type` values explicitly.

--- a/src/okn_embeddings/config/settings.py
+++ b/src/okn_embeddings/config/settings.py
@@ -26,6 +26,24 @@ class AppSettings(BaseSettings):
     qdrant_timeout: int = 30
     model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
 
+    # Embedding throughput knobs, both unset by default because onnxruntime's
+    # own defaults win on an ordinary machine. Measured on 8 cores with
+    # all-MiniLM-L6-v2: leaving both alone gives 41.6 records/s, while
+    # embed_threads=1 with embed_parallel=0 gives 19.4 -- the model is small
+    # enough that per-process sessions contend for the same cores rather than
+    # adding throughput.
+    #
+    # They exist because that balance can invert: on a machine with many more
+    # cores, intra-op threading stops scaling before the cores run out, and
+    # splitting into processes (embed_parallel=N with embed_threads=1, so the
+    # workers do not oversubscribe) can win. Measure before setting either.
+    #
+    # embed_threads: onnxruntime threads per session. None = its default.
+    # embed_parallel: worker processes. None = no multiprocessing, 0 = one per
+    # core, N = N workers.
+    embed_threads: int | None = None
+    embed_parallel: int | None = None
+
 
 def load_settings():
     return AppSettings()

--- a/src/okn_embeddings/core/embedding.py
+++ b/src/okn_embeddings/core/embedding.py
@@ -21,10 +21,27 @@ class Embedder(Protocol):
 
 
 class FastEmbedEmbedder:
-    """Embedder backed by fastembed (onnxruntime, no torch)."""
+    """Embedder backed by fastembed (onnxruntime, no torch).
 
-    def __init__(self, model_name: str):
-        self._model = TextEmbedding(model_name=model_name)
+    `threads` and `parallel` are the throughput knobs (see `AppSettings`);
+    both default to None, which leaves onnxruntime's own defaults in place --
+    the fastest configuration on an ordinary machine, because the model is
+    small enough that intra-op threading already uses every core.
+
+    GPU execution needs no setting here: fastembed's device selection
+    defaults to auto, so installing the `fastembed-gpu` package (which brings
+    onnxruntime-gpu) is enough to pick up a CUDA device.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        threads: int | None = None,
+        parallel: int | None = None,
+    ):
+        self._model = TextEmbedding(model_name=model_name, threads=threads)
+        self.threads = threads
+        self.parallel = parallel
 
     def embed(self, text: str) -> np.ndarray:
         return self.embed_many([text])[0]
@@ -32,7 +49,7 @@ class FastEmbedEmbedder:
     def embed_many(self, texts: list[str]) -> list[np.ndarray]:
         return [
             np.asarray(vector, dtype=np.float32)
-            for vector in self._model.embed(texts)
+            for vector in self._model.embed(texts, parallel=self.parallel)
         ]
 
 
@@ -42,4 +59,8 @@ def make_embedder(settings: "AppSettings") -> Embedder:
     The single place backend selection would branch if a non-fastembed model
     is ever needed.
     """
-    return FastEmbedEmbedder(settings.model_name)
+    return FastEmbedEmbedder(
+        settings.model_name,
+        threads=settings.embed_threads,
+        parallel=settings.embed_parallel,
+    )

--- a/src/okn_embeddings/indexing/cli.py
+++ b/src/okn_embeddings/indexing/cli.py
@@ -188,12 +188,24 @@ def sample_types_cmd(
             help="Maximum literal examples to include per predicate.",
         ),
     ] = 3,
+    seed: Annotated[
+        int | None,
+        typer.Option(
+            "--seed",
+            help=(
+                "Sampling seed. Defaults to one derived from the graph "
+                "itself, so repeated runs report the same subjects; pass a "
+                "different value to draw a different sample."
+            ),
+        ),
+    ] = None,
 ):
     graph = load_graph(hdt_file)
     records = sample_types(
         graph,
         limit=limit,
         values_limit=values_limit,
+        seed=seed,
     )
 
     if text:
@@ -230,13 +242,24 @@ def sample_targets_cmd(
         typer.Option(
             "--limit",
             min=1,
-            help="Maximum number of root nodes to process per target.",
+            help="Maximum number of root nodes to sample per target.",
         ),
     ] = 5,
+    seed: Annotated[
+        int | None,
+        typer.Option(
+            "--seed",
+            help=(
+                "Sampling seed. Defaults to one derived from the graph "
+                "itself, so repeated runs sample the same roots; pass a "
+                "different value to draw a different sample."
+            ),
+        ),
+    ] = None,
 ):
     graph = load_graph(hdt_file)
     config = MaterializationConfiguration.from_toml(config_toml)
-    records = sample_targets(graph, config, limit=limit)
+    records = sample_targets(graph, config, limit=limit, seed=seed)
 
     if text:
         write_sample_targets_text(records, output)

--- a/src/okn_embeddings/indexing/models.py
+++ b/src/okn_embeddings/indexing/models.py
@@ -70,6 +70,14 @@ class GraphConfiguration(BaseModel):
     # geometry blobs, or other low-semantic-value relationships.
     ignore_predicates: list[str] = Field(default_factory=list)
 
+    # When non-empty, ONLY these predicates are walked; everything else is
+    # skipped as if ignored. Prefer this over `ignore_predicates` when a graph
+    # has many low-value predicates and few good ones -- an ontology whose
+    # relation vocabulary is open-ended (and grows with each release) cannot be
+    # covered by a blacklist, but its handful of annotation predicates is a
+    # stable allowlist.
+    include_predicates: list[str] = Field(default_factory=list)
+
     # Maximum number of objects to include per predicate for each subject.
     # When a predicate has more values than this, a stable hash-based selection
     # is used so repeated runs are deterministic.
@@ -170,6 +178,11 @@ class MaterializationConfiguration(BaseModel):
             if predicate not in ignore_predicates:
                 ignore_predicates.append(predicate)
 
+        include_predicates = [*defaults.include_predicates]
+        for predicate in target.include_predicates:
+            if predicate not in include_predicates:
+                include_predicates.append(predicate)
+
         predicate_limit = None
         if "predicate_limit" in defaults.model_fields_set:
             predicate_limit = defaults.predicate_limit
@@ -190,6 +203,7 @@ class MaterializationConfiguration(BaseModel):
             type=target.type,
             label_predicates=label_predicates,
             ignore_predicates=ignore_predicates,
+            include_predicates=include_predicates,
             predicate_limit=predicate_limit,
             expansion_limit=expansion_limit,
             include_rdfs_label=include_rdfs_label,

--- a/src/okn_embeddings/indexing/reader.py
+++ b/src/okn_embeddings/indexing/reader.py
@@ -116,7 +116,15 @@ class RDFLibGraphReader(GraphReader):
 
 
 class HDTGraphReader(GraphReader):
-    """Reader that reads the native HDT document, skipping rdflib terms."""
+    """Reader that reads the native HDT document, skipping rdflib terms.
+
+    Every `search_triples` call here discards the second element of the
+    returned pair. Do not start using it as a triple count: for
+    predicate-only patterns it is the number of distinct *subjects*, and
+    `TripleIterator.size_hint()` reports that as accurate. Measured on
+    Ubergraph, `? rdfs:subClassOf ?` reports 3,886,036 against 112,020,318
+    triples actually iterated. Counting means iterating.
+    """
 
     def __init__(self, graph: Graph):
         self.graph = graph

--- a/src/okn_embeddings/indexing/sample.py
+++ b/src/okn_embeddings/indexing/sample.py
@@ -1,8 +1,10 @@
+import hashlib
 import json
+import random
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, TypeVar
 
 from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import RDF
@@ -10,7 +12,61 @@ from rdflib.namespace import RDF
 from .models import GraphConfiguration, MaterializationConfiguration
 from .output import OutputRecord
 from .reader import graph_reader
-from .textify import Textifier, materialize_records
+from .textify import (
+    Textifier,
+    finish_records,
+    merge_worker_record,
+)
+
+T = TypeVar("T")
+
+# Seed used for graphs whose identity cannot be read (non-HDT stores, mainly
+# in tests). Any constant will do; it only has to be stable.
+FALLBACK_SEED = 0
+
+
+def graph_seed(graph: Graph) -> int:
+    """A reproducible sampling seed derived from the graph's own identity.
+
+    Read from the HDT header, which costs nothing, rather than hashing the
+    file: the samples then stay the same when the file is renamed, copied, or
+    moved, and change when the graph itself does.
+    """
+    document = getattr(graph.store, "hdt_document", None)
+    if document is None:
+        return FALLBACK_SEED
+
+    identity = "|".join(
+        str(value)
+        for value in (
+            document.total_triples,
+            document.nb_subjects,
+            document.nb_predicates,
+            document.nb_objects,
+        )
+    )
+    digest = hashlib.sha256(identity.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big")
+
+
+def reservoir_sample(
+    items: Iterable[T], k: int, rng: random.Random
+) -> list[T]:
+    """A uniform `k`-sample of `items`, whose length need not be known.
+
+    Vitter's Algorithm R: keep the first k, then admit the i-th item with
+    probability k/(i+1), evicting a uniformly chosen incumbent. Every item
+    ends up in the reservoir with probability k/n for the final n, while
+    memory stays O(k) -- which is the point on a graph with millions of
+    subjects per type.
+    """
+    reservoir: list[T] = []
+    for i, item in enumerate(items):
+        if i < k:
+            reservoir.append(item)
+        elif (j := rng.randrange(i + 1)) < k:
+            reservoir[j] = item
+    return reservoir
 
 
 @dataclass
@@ -66,18 +122,42 @@ def sample_types(
     graph: Graph,
     limit: int = 5,
     values_limit: int = 3,
+    seed: int | None = None,
 ) -> list[TypeSampleRecord]:
+    """Survey the graph's types, with a uniform sample of each type's subjects.
+
+    Sampling is seeded (from the graph's identity unless `seed` is given), so
+    a run over the same graph always reports the same exemplars.
+    """
+    # Reproducibility, not secrecy: a seeded Mersenne Twister is the point.
+    rng = random.Random(  # noqa: S311
+        graph_seed(graph) if seed is None else seed
+    )
+
     counts: defaultdict[str, int] = defaultdict(int)
     samples: defaultdict[str, list[str]] = defaultdict(list)
 
+    # One reservoir per type, sharing this single pass. Each type's counter is
+    # its own `i`, so types spanning five orders of magnitude -- 3.9M classes
+    # and 63 ontologies -- self-adjust without knowing their size in advance.
     for subject, type_node in graph.subject_objects(RDF.type):
         if not isinstance(subject, URIRef) or not isinstance(type_node, URIRef):
             continue
 
         type_iri = str(type_node)
-        counts[type_iri] += 1
-        if len(samples[type_iri]) < limit:
-            samples[type_iri].append(str(subject))
+        seen = counts[type_iri]
+        counts[type_iri] = seen + 1
+
+        bucket = samples[type_iri]
+        if seen < limit:
+            bucket.append(str(subject))
+        elif (j := rng.randrange(seen + 1)) < limit:
+            bucket[j] = str(subject)
+
+    # Present each reservoir in a stable order; the *set* is what the sampling
+    # makes uniform.
+    for bucket in samples.values():
+        bucket.sort()
 
     config = GraphConfiguration()
     textifier = Textifier(graph_reader(graph))
@@ -232,21 +312,39 @@ def sample_targets(
     graph: Graph,
     config: MaterializationConfiguration,
     limit: int = 5,
+    seed: int | None = None,
 ) -> list[TargetSampleRecord]:
+    """Materialize a uniform sample of each target's roots.
+
+    Unlike a full `textify` run this samples rather than taking the first
+    `limit` roots, so the sampled documents represent the whole target rather
+    than whichever IRIs sort first. Seeded like `sample_types`.
+    """
+    # Reproducibility, not secrecy: a seeded Mersenne Twister is the point.
+    rng = random.Random(  # noqa: S311
+        graph_seed(graph) if seed is None else seed
+    )
+    reader = graph_reader(graph)
+    textifier = Textifier(reader, config)
     records = []
 
     for target in config.targets:
         target_config = config.for_target(target)
+        roots = reservoir_sample(
+            reader.root_iris(target_config.type), limit, rng
+        )
+
+        by_digest: dict[str, OutputRecord] = {}
+        for iri in sorted(roots):
+            merge_worker_record(
+                by_digest, textifier.materialize_one(iri, target_config)
+            )
+
         records.append(
             TargetSampleRecord(
                 target=target,
                 type=target_config.type,
-                records=materialize_records(
-                    graph,
-                    config,
-                    target=target,
-                    limit=limit,
-                ),
+                records=finish_records(by_digest),
             )
         )
 

--- a/src/okn_embeddings/indexing/sample.py
+++ b/src/okn_embeddings/indexing/sample.py
@@ -73,7 +73,14 @@ def reservoir_sample(
 class LiteralPredicateSample:
     predicate: str
     label: str
+    # Occurrences across the sampled subjects -- NOT a graph-wide total.
     count: int
+    # `count` divided by the number of subjects sampled: how many values a
+    # subject of this type carries for this predicate, on average. High fanout
+    # is a prompt to decide, not a verdict -- a state's counties and a
+    # class's inferred ancestors both score in the tens, but sampling a few
+    # counties is informative while sampling a few ancestors is not.
+    mean_per_subject: float
     values: list[str]
 
 
@@ -95,7 +102,9 @@ class ObjectSample:
 class ObjectPredicateSample:
     predicate: str
     label: str
+    # As above: occurrences across the sample, and the per-subject mean.
     count: int
+    mean_per_subject: float
     object_types: list[ObjectTypeSample]
     object_label_predicates: list[LiteralPredicateSample]
     sample_objects: list[ObjectSample]
@@ -234,11 +243,17 @@ def sample_types(
                         )
                     )
 
+        # Counts below are over the sampled subjects, so the per-subject mean
+        # divides by how many were actually sampled (fewer than `limit` when
+        # the type is smaller than that).
+        sampled = len(samples[type_iri]) or 1
+
         literal_predicates = [
             LiteralPredicateSample(
                 predicate=pred_iri,
                 label=textifier.predicate_text(URIRef(pred_iri), config),
                 count=count,
+                mean_per_subject=round(count / sampled, 2),
                 values=predicate_values[pred_iri],
             )
             for pred_iri, count in sorted(
@@ -252,6 +267,7 @@ def sample_types(
                 predicate=pred_iri,
                 label=textifier.predicate_text(URIRef(pred_iri), config),
                 count=count,
+                mean_per_subject=round(count / sampled, 2),
                 object_types=[
                     ObjectTypeSample(
                         type=object_type_iri,
@@ -275,6 +291,7 @@ def sample_types(
                             config,
                         ),
                         count=label_pred_count,
+                        mean_per_subject=round(label_pred_count / sampled, 2),
                         values=object_label_values[pred_iri][label_pred_iri],
                     )
                     for label_pred_iri, label_pred_count in sorted(
@@ -379,14 +396,18 @@ def write_sample_types_text(
             f.write("literal predicates:\n")
             for pred in record.literal_predicates:
                 f.write(
-                    f"- {pred.label} ({pred.predicate}) [count={pred.count}]\n"
+                    f"- {pred.label} ({pred.predicate}) "
+                    f"[count={pred.count}, "
+                    f"per subject={pred.mean_per_subject}]\n"
                 )
                 for value in pred.values:
                     f.write(f"  - {value}\n")
             f.write("object predicates:\n")
             for pred in record.object_predicates:
                 f.write(
-                    f"- {pred.label} ({pred.predicate}) [count={pred.count}]\n"
+                    f"- {pred.label} ({pred.predicate}) "
+                    f"[count={pred.count}, "
+                    f"per subject={pred.mean_per_subject}]\n"
                 )
                 f.write("  object types:\n")
                 for object_type in pred.object_types:

--- a/src/okn_embeddings/indexing/textify.py
+++ b/src/okn_embeddings/indexing/textify.py
@@ -98,11 +98,14 @@ class Textifier:
     ) -> Generator[tuple[int, GraphTerm, GraphTerm, GraphTerm], None, None]:
         root_term = self.reader.term(root)
         ignore_predicates = set(config.ignore_predicates or [])
+        include_predicates = set(config.include_predicates or [])
 
         objects_by_predicate: defaultdict[GraphTerm, list[GraphTerm]] = (
             defaultdict(list)
         )
         for p, o in self.reader.predicate_objects(root_term):
+            if include_predicates and p.value not in include_predicates:
+                continue
             if p.value in ignore_predicates:
                 continue
             objects_by_predicate[p].append(o)

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -514,3 +514,48 @@ def test_graph_seed_is_derived_from_hdt_header_stats():
     assert graph_seed(fake(600)) == graph_seed(fake(600))
     assert graph_seed(fake(600)) != graph_seed(fake(601))
     assert graph_seed(fake(600)) != FALLBACK_SEED
+
+
+def test_sample_types_reports_fanout_per_subject():
+    # Two Things: one with a single-valued annotation, one predicate with
+    # many values per subject -- the shape that distinguishes an annotation
+    # from an edge into a closure.
+    graph = Graph()
+    thing = URIRef("http://example.com/Thing")
+    ancestor_of = URIRef("http://example.com/ancestorOf")
+    name = URIRef("http://example.com/name")
+    for i in range(2):
+        subject = URIRef(f"http://example.com/s{i}")
+        graph.add((subject, RDF.type, thing))
+        graph.add((subject, name, Literal(f"name {i}")))
+        for a in range(10):
+            graph.add((subject, ancestor_of, URIRef(f"http://example.com/a{a}")))
+
+    record = sample_types(graph, limit=2, seed=0)[0]
+
+    literal = {p.predicate: p for p in record.literal_predicates}
+    objects = {p.predicate: p for p in record.object_predicates}
+
+    assert literal[str(name)].count == 2
+    assert literal[str(name)].mean_per_subject == 1.0
+    # 10 objects each across 2 sampled subjects.
+    assert objects[str(ancestor_of)].count == 20
+    assert objects[str(ancestor_of)].mean_per_subject == 10.0
+
+
+def test_mean_per_subject_divides_by_subjects_actually_sampled():
+    # Only 3 subjects exist but limit is 10; the mean must divide by 3.
+    graph = Graph()
+    thing = URIRef("http://example.com/Thing")
+    name = URIRef("http://example.com/name")
+    for i in range(3):
+        subject = URIRef(f"http://example.com/s{i}")
+        graph.add((subject, RDF.type, thing))
+        graph.add((subject, name, Literal(f"name {i}")))
+
+    record = sample_types(graph, limit=10, seed=0)[0]
+    predicate = record.literal_predicates[0]
+
+    assert len(record.sample_iris) == 3
+    assert predicate.count == 3
+    assert predicate.mean_per_subject == 1.0

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -144,6 +144,74 @@ def test_walk_graph_uses_ignore_predicates_limit_and_depth():
     )
 
 
+def test_walk_graph_include_predicates_is_an_allowlist():
+    graph = load_fixture("walk_graph.ttl")
+    root = URIRef("http://example.com/root")
+    pred = URIRef("http://example.com/hasPart")
+    ignored = URIRef("http://example.com/ignored")
+
+    config = GraphConfiguration(
+        include_predicates=[str(ignored)],
+        expansion_limit=0,
+    )
+
+    triples = list(Textifier(graph_reader(graph)).walk(root, config))
+
+    # Only the allowed predicate survives, even though it is the one the
+    # blacklist test skips.
+    assert {p.value for _, _, p, _ in triples} == {str(ignored)}
+    assert all(p.value != str(pred) for _, _, p, _ in triples)
+
+
+def test_walk_graph_ignore_predicates_still_applies_within_the_allowlist():
+    graph = load_fixture("walk_graph.ttl")
+    root = URIRef("http://example.com/root")
+    pred = URIRef("http://example.com/hasPart")
+    ignored = URIRef("http://example.com/ignored")
+
+    config = GraphConfiguration(
+        include_predicates=[str(pred), str(ignored)],
+        ignore_predicates=[str(ignored)],
+        expansion_limit=0,
+    )
+
+    triples = list(Textifier(graph_reader(graph)).walk(root, config))
+
+    assert {p.value for _, _, p, _ in triples} == {str(pred)}
+
+
+def test_walk_graph_empty_include_predicates_allows_everything():
+    graph = load_fixture("walk_graph.ttl")
+    root = URIRef("http://example.com/root")
+
+    config = GraphConfiguration(expansion_limit=0)
+
+    triples = list(Textifier(graph_reader(graph)).walk(root, config))
+
+    assert len({p.value for _, _, p, _ in triples}) == 2
+
+
+def test_config_merges_include_predicates_from_defaults_and_target():
+    config = MaterializationConfiguration.model_validate(
+        {
+            "defaults": {
+                "include_predicates": ["http://example.com/keepDefault"],
+            },
+            "targets": {
+                "thing": {
+                    "type": "http://example.com/Thing",
+                    "include_predicates": ["http://example.com/keepTarget"],
+                },
+            },
+        }
+    )
+
+    assert config.for_target("thing").include_predicates == [
+        "http://example.com/keepDefault",
+        "http://example.com/keepTarget",
+    ]
+
+
 def test_build_embedding_text_formats_labels_literals_and_nested_nodes():
     graph = load_fixture("embedding_text.ttl")
     root = URIRef("http://example.com/root")

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -1,6 +1,9 @@
+import random
+from collections import Counter
 from pathlib import Path
+from types import SimpleNamespace
 
-from rdflib import Graph, URIRef
+from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import RDF, RDFS
 
 from okn_embeddings.indexing.models import (
@@ -8,7 +11,13 @@ from okn_embeddings.indexing.models import (
     MaterializationConfiguration,
 )
 from okn_embeddings.indexing.reader import graph_reader
-from okn_embeddings.indexing.sample import sample_targets, sample_types
+from okn_embeddings.indexing.sample import (
+    FALLBACK_SEED,
+    graph_seed,
+    reservoir_sample,
+    sample_targets,
+    sample_types,
+)
 from okn_embeddings.indexing.text import (
     effective_label_predicates,
     fallback_label,
@@ -379,10 +388,129 @@ def test_sample_targets_uses_configured_materialization():
         }
     )
 
-    records = sample_targets(graph, config, limit=1)
+    records = sample_targets(graph, config, limit=1, seed=0)
 
     assert len(records) == 1
     assert records[0].target == "thing"
     assert records[0].type == str(root_type)
     assert len(records[0].records) == 1
-    assert records[0].records[0].embedding_text == "label: a\nvalue: same"
+    # Which root is sampled is up to the RNG; whichever it is, the record is
+    # materialized through the configured target.
+    assert records[0].records[0].embedding_text in {
+        "label: a\nvalue: same",
+        "label: b\nvalue: same",
+        "label: c\nvalue: different",
+    }
+
+
+# --- sampling: uniform, seeded, reproducible -----------------------------
+
+
+def _many_things(n: int) -> Graph:
+    """A graph of `n` ex:Thing roots named in iteration order t00, t01, …"""
+    graph = Graph()
+    thing = URIRef("http://example.com/Thing")
+    for i in range(n):
+        subject = URIRef(f"http://example.com/t{i:02d}")
+        graph.add((subject, RDF.type, thing))
+        graph.add((subject, RDFS.label, Literal(f"thing {i:02d}")))
+    return graph
+
+
+def test_reservoir_sample_keeps_k_items_from_the_stream():
+    picked = reservoir_sample(range(1000), 5, random.Random(1))
+
+    assert len(picked) == 5
+    assert len(set(picked)) == 5
+    assert all(0 <= item < 1000 for item in picked)
+
+
+def test_reservoir_sample_returns_everything_when_shorter_than_k():
+    assert sorted(reservoir_sample(range(3), 10, random.Random(1))) == [
+        0,
+        1,
+        2,
+    ]
+
+
+def test_reservoir_sample_is_uniform():
+    # Every item should land in the reservoir about k/n of the time. With
+    # n=10, k=2 and 4000 draws, each item's expected share is 20%.
+    rng = random.Random(7)
+    hits = Counter()
+    trials = 4000
+    for _ in range(trials):
+        hits.update(reservoir_sample(range(10), 2, rng))
+
+    shares = [hits[i] / trials for i in range(10)]
+    assert all(0.15 < share < 0.25 for share in shares), shares
+
+
+def test_sample_types_looks_past_the_first_n_subjects():
+    graph = _many_things(60)
+
+    records = sample_types(graph, limit=3, seed=99)
+    sampled = set(records[0].sample_iris)
+
+    assert len(sampled) == 3
+    # The old behavior kept exactly t00, t01, t02 -- the lexicographically
+    # first roots. A uniform sample of 3 from 60 essentially never does.
+    assert sampled != {
+        "http://example.com/t00",
+        "http://example.com/t01",
+        "http://example.com/t02",
+    }
+
+
+def test_sample_types_is_reproducible_for_a_seed():
+    graph = _many_things(60)
+
+    first = sample_types(graph, limit=3, seed=99)[0].sample_iris
+    again = sample_types(graph, limit=3, seed=99)[0].sample_iris
+    other = sample_types(graph, limit=3, seed=1234)[0].sample_iris
+
+    assert first == again
+    assert first != other
+
+
+def test_sample_targets_looks_past_the_first_n_roots():
+    graph = _many_things(60)
+    config = MaterializationConfiguration.model_validate(
+        {
+            "targets": {
+                "thing": {
+                    "type": "http://example.com/Thing",
+                    "ignore_predicates": [str(RDF.type)],
+                }
+            }
+        }
+    )
+
+    records = sample_targets(graph, config, limit=3, seed=99)[0].records
+    labels = {record.label for record in records}
+
+    assert len(labels) == 3
+    assert labels != {"thing 00", "thing 01", "thing 02"}
+
+
+def test_graph_seed_falls_back_without_an_hdt_document():
+    assert graph_seed(Graph()) == FALLBACK_SEED
+
+
+def test_graph_seed_is_derived_from_hdt_header_stats():
+    def fake(total_triples):
+        return SimpleNamespace(
+            store=SimpleNamespace(
+                hdt_document=SimpleNamespace(
+                    total_triples=total_triples,
+                    nb_subjects=17,
+                    nb_predicates=3,
+                    nb_objects=25,
+                )
+            )
+        )
+
+    # Same graph identity -> same seed; a different graph -> different seed.
+    assert graph_seed(fake(600)) == graph_seed(fake(600))
+    assert graph_seed(fake(600)) != graph_seed(fake(601))
+    assert graph_seed(fake(600)) != FALLBACK_SEED

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -5,7 +5,8 @@ import pytest
 from qdrant_client.models import ScoredPoint
 
 from okn_embeddings.config.context import AppContext
-from okn_embeddings.core.embedding import FastEmbedEmbedder
+from okn_embeddings.config.settings import AppSettings
+from okn_embeddings.core.embedding import FastEmbedEmbedder, make_embedder
 from okn_embeddings.core.results import summarize_point
 from okn_embeddings.indexing.upload import (
     chunks,
@@ -14,6 +15,8 @@ from okn_embeddings.indexing.upload import (
     point_id,
     upload_file,
 )
+
+_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 
 
 def _write_records(path, n: int) -> None:
@@ -211,3 +214,22 @@ def test_embed_matches_embed_many(embedder: FastEmbedEmbedder):
 
     assert len(many) == 2
     assert np.array_equal(one, many[0])
+
+
+# --- embedding throughput knobs ---
+
+
+def test_make_embedder_passes_throughput_settings():
+    embedder = make_embedder(
+        AppSettings(model_name=_MODEL, embed_threads=2, embed_parallel=3)
+    )
+
+    assert embedder.threads == 2
+    assert embedder.parallel == 3
+
+
+def test_throughput_settings_default_to_onnxruntime_defaults():
+    embedder = make_embedder(AppSettings(model_name=_MODEL))
+
+    assert embedder.threads is None
+    assert embedder.parallel is None


### PR DESCRIPTION
* Improve the machinery to generate `textify` configs (especially the `include_predicates` option)
* Instead of sampling types as first-N, use reservoir sampling for a (deterministic) randomized subset
* Update the agent skill to reflect both of the above